### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/DS1307/keywords.txt
+++ b/DS1307/keywords.txt
@@ -6,38 +6,38 @@
 # Datatypes (KEYWORD1)                # 
 #######################################
 
-DS1307  	KEYWORD1
+DS1307	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 isEnabled	KEYWORD2
 check24Hour	KEYWORD2
-getTime		KEYWORD2
-getDate		KEYWORD2
+getTime	KEYWORD2
+getDate	KEYWORD2
 dayOfWeek	KEYWORD2
-getDTC		KEYWORD2
+getDTC	KEYWORD2
 enableRTC	KEYWORD2
 disableRTC	KEYWORD2
-set24		KEYWORD2
-set12		KEYWORD2
-setup		KEYWORD2
-setTime		KEYWORD2
-setDate		KEYWORD2
+set24	KEYWORD2
+set12	KEYWORD2
+setup	KEYWORD2
+setTime	KEYWORD2
+setDate	KEYWORD2
 setDayOfWeek	KEYWORD2
-setDTC		KEYWORD2
+setDTC	KEYWORD2
 bcd_to_dec	KEYWORD2
 dec_to_bcd	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-#DS1307_ADDR		LITERAL
-#DS1307CH		LITERAL
-#DS1307_SEC		LITERAL
-#DS1307_MODE		LITERAL
-#DS1307_24HR		LITERAL   
-#DS1307_AMPM		LITERAL
-#DS1307_12HR		LITERAL
+#DS1307_ADDR	LITERAL
+#DS1307CH	LITERAL
+#DS1307_SEC	LITERAL
+#DS1307_MODE	LITERAL
+#DS1307_24HR	LITERAL
+#DS1307_AMPM	LITERAL
+#DS1307_12HR	LITERAL
 #DS1307_EPOCH	LITERAL
 

--- a/ThumbStick/keywords.txt
+++ b/ThumbStick/keywords.txt
@@ -11,9 +11,9 @@ ThumbStick	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-getH		KEYWORD2
-getV		KEYWORD2
-getS		KEYWORD2
+getH	KEYWORD2
+getV	KEYWORD2
+getS	KEYWORD2
 getMapLow	KEYWORD2
 getMapHigh	KEYWORD2
 getCenter	KEYWORD2

--- a/pushbutton/keywords.txt
+++ b/pushbutton/keywords.txt
@@ -6,12 +6,12 @@
 # Datatypes (KEYWORD1)                # 
 #######################################
 
-pushbutton		KEYWORD1
+pushbutton	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-isPressed		KEYWORD2
+isPressed	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords